### PR TITLE
Fix broken links in Spark UI and use private IPs instead of hostnames

### DIFF
--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -278,8 +278,8 @@ class EC2Cluster(FlintrockCluster):
         print('  state: {s}'.format(s=self.state))
         print('  node-count: {nc}'.format(nc=len(self.instances)))
         if self.state == 'running':
-            print('  master:', self.master_host)
-            print('\n    - '.join(['  slaves:'] + self.slave_hosts))
+            print('  master:', self.master_ip if self.use_private_network else self.master_host)
+            print('\n    - '.join(['  slaves:'] + self.slave_ips if self.use_private_network else self.slave_hosts))
         # print('...')
 
 

--- a/flintrock/flintrock.py
+++ b/flintrock/flintrock.py
@@ -457,13 +457,13 @@ def describe(
     if cluster_name:
         cluster = clusters[0]
         if master_hostname_only:
-            print(cluster.master_host)
+            print(cluster.master_ip if ec2_use_private_network else cluster.master_host)
         else:
             cluster.print()
     else:
         if master_hostname_only:
             for cluster in sorted(clusters, key=lambda x: x.name):
-                print(cluster.name + ':', cluster.master_host)
+                print(cluster.name + ':', cluster.master_ip if ec2_use_private_network else cluster.master_host)
         else:
             print("Found {n} cluster{s}{space}{search_area}.".format(
                 n=len(clusters),

--- a/flintrock/templates/spark/conf/spark-env.sh
+++ b/flintrock/templates/spark/conf/spark-env.sh
@@ -6,14 +6,18 @@ export SPARK_LOCAL_DIRS="{root_ephemeral_dirs}"
 export SPARK_EXECUTOR_INSTANCES="1"
 export SPARK_WORKER_CORES="$(nproc)"
 
-export SPARK_MASTER_IP="{master_host}"
+export SPARK_MASTER_IP="{master_ip}"
 
 # TODO: Make this dependent on HDFS install.
 export HADOOP_CONF_DIR="/home/$(logname)/hadoop/conf"
 
 # TODO: Make this non-EC2-specific.
-# Bind Spark's web UIs to this machine's public EC2 hostname
-export SPARK_PUBLIC_DNS="$(curl --silent http://169.254.169.254/latest/meta-data/public-hostname)"
+# Bind Spark's web UIs to this machine's public EC2 hostname. Fallback to private IP if this machine has no public hostname
+SPARK_PUBLIC_DNS="$(curl --silent http://169.254.169.254/latest/meta-data/public-hostname)"
+if [[ -z "$SPARK_PUBLIC_DNS" ]]; then
+  SPARK_PUBLIC_DNS="$(curl --silent http://169.254.169.254/latest/meta-data/local-ipv4)"
+fi
+export SPARK_PUBLIC_DNS
 
 # TODO: Set a high ulimit for large shuffles
 # Need to find a way to do this, since "sudo ulimit..." doesn't fly.


### PR DESCRIPTION
This PR  makes the following changes: 
- Fix broken links in Spark UI : use private IP for SPARK_PUBLIC_DNS when a machine has no public hostname
- Use private IPs instead of hostnames
