### PR TITLE
ref: use S3 endpoint and remove /etc/hosts hack

### DIFF
--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -439,8 +439,8 @@ class FlintrockCluster:
         Generate a template mapping from a FlintrockCluster instance that we can use
         to fill in template parameters.
         """
-        root_dir = posixpath.join(self.storage_dirs.root, service)
-        ephemeral_dirs = ','.join(posixpath.join(path, service) for path in self.storage_dirs.ephemeral)
+        root_dir = posixpath.join(self.storage_dirs.root, 'hdfs')
+        ephemeral_dirs = ','.join(posixpath.join(path, 'hdfs') for path in self.storage_dirs.ephemeral)
 
         template_mapping = {
             'master_ip': self.master_ip,

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -596,19 +596,6 @@ def setup_node(
     cluster.storage_dirs.root = storage_dirs['root']
     cluster.storage_dirs.ephemeral = storage_dirs['ephemeral']
 
-    if cluster.subnet_is_private:
-        print("[{h}] Configuring hostname...".format(h=host))
-        # TODO: handle hostname for other regions than eu-west-1
-        ssh_check_output(
-            client=ssh_client,
-            command="""
-                set -e
-
-                fullname=`hostname`.eu-west-1.compute.internal
-
-                echo "{h} $fullname $(hostname)" |sudo tee -a /etc/hosts
-                """.format(h=host))
-
     ensure_java8(ssh_client)
 
     for service in services:

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -415,6 +415,16 @@ class EC2Cluster(FlintrockCluster):
                     ['  slaves:'] + ((self.slave_ips if self.use_private_network else self.slave_hosts) if self.num_slaves > 0 else [])))
         # print('...')
 
+    def generate_template_mapping(self, *, service: str) -> dict:
+        template_mapping = super().generate_template_mapping(service=service)
+        template_mapping['ec2_region'] = self.region
+
+        credentials = botocore.session.get_session().get_credentials()
+        template_mapping['access_key'] = credentials.access_key
+        template_mapping['secret_key'] = credentials.secret_key
+
+        return template_mapping
+
 
 def get_default_vpc(region: str) -> 'boto3.resources.factory.ec2.Vpc':
     """

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -320,8 +320,6 @@ class EC2Cluster(FlintrockCluster):
         self.slave_instances += new_slave_instances
         self.wait_for_state('running')
 
-        self.update_hosts(user=user, identity_file=identity_file)
-
         new_slaves = {i.private_ip_address if self.use_private_network else i.public_ip_address for i in self.slave_instances} - existing_slaves
 
         super().add_slaves(
@@ -366,8 +364,6 @@ class EC2Cluster(FlintrockCluster):
                 ])
             .terminate())
 
-        self.update_hosts(user=user, identity_file=identity_file)
-
     def run_command_check(self):
         if self.state != 'running':
             raise ClusterInvalidState(
@@ -398,33 +394,6 @@ class EC2Cluster(FlintrockCluster):
             identity_file=identity_file,
             local_path=local_path,
             remote_path=remote_path)
-
-    def update_hosts(self, user: str, identity_file: str):
-        commands="""
-            set -e
-            sudo /bin/bash -c 'echo "#" >/etc/hosts'
-            """
-        for instance in self.instances:
-            commands+="""
-                sudo /bin/bash -c 'echo "{ip}     {private_dns_name} {public_dns_name}" >>/etc/hosts'
-                """.format(
-                    ip=shlex.quote(instance.private_ip_address if self.use_private_network else instance.public_ip_address),
-                    private_dns_name=shlex.quote(instance.private_dns_name),
-                    public_dns_name=shlex.quote(instance.public_dns_name))
-        for instance in self.instances:
-            instance_command=commands+"""
-                sudo /bin/bash -c 'echo "{ip}     {local_hostname}" >>/etc/hosts'
-                """.format(
-                        ip=shlex.quote(instance.private_ip_address if self.use_private_network else instance.public_ip_address),
-                        local_hostname=shlex.quote("$(hostname)"))
-            ssh_check_output(
-                client=get_ssh_client(
-                    user=user,
-                    host=(instance.private_ip_address if self.use_private_network else instance.public_ip_address),
-                    identity_file=identity_file,
-                    wait=True,
-                    print_status=False),
-                command=instance_command)
 
     def print(self):
         """
@@ -1000,8 +969,6 @@ def launch(
         use_private_network=use_private_network)
 
     cluster.wait_for_state('running')
-
-    cluster.update_hosts(user=user, identity_file=identity_file)
 
     provision_cluster(
         cluster=cluster,

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -292,6 +292,7 @@ class Spark(FlintrockService):
             ssh_client: paramiko.client.SSHClient,
             cluster: FlintrockCluster):
         template_paths = [
+            'spark/conf/core-site.xml',
             'spark/conf/spark-env.sh',
             'spark/conf/slaves']
         for template_path in template_paths:

--- a/flintrock/templates/hadoop/conf/core-site.xml
+++ b/flintrock/templates/hadoop/conf/core-site.xml
@@ -9,6 +9,6 @@
 
   <property>
     <name>fs.defaultFS</name>
-    <value>hdfs://{master_host}:9000</value>
+    <value>hdfs://{master_ip}:9000</value>
   </property>
 </configuration>

--- a/flintrock/templates/spark/conf/core-site.xml
+++ b/flintrock/templates/spark/conf/core-site.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>hadoop.tmp.dir</name>
+    <value>{root_ephemeral_dirs}</value>
+  </property>
+
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://{master_ip}:9000</value>
+    <description> By default, write to HDFS if no scheme is specified</description>
+  </property>
+
+  <property>
+    <name>fs.s3a.endpoint</name>
+    <value>s3-{ec2_region}.amazonaws.com</value>
+    <final>true</final>
+    <description>AWS S3 endpoint to connect to. An up-to-date list is
+      provided in the AWS Documentation: regions and endpoints. Without this
+      property, the standard region (s3.amazonaws.com) is assumed.
+    </description>
+  </property>
+
+  <property>
+    <name>fs.s3a.impl</name>
+    <value>org.apache.hadoop.fs.s3a.S3AFileSystem</value>
+  </property>
+
+  <property>
+    <name>fs.s3a.access.key</name>
+    <value>{access_key}</value>
+  </property>
+
+  <property>
+    <name>fs.s3a.secret.key</name>
+    <value>{secret_key}</value>
+  </property>
+
+  <property>
+    <name>fs.s3a.buffer.dir</name>
+    <value>/home/ec2-user/spark/work,/tmp</value>
+  </property>
+
+  <property>
+    <name>fs.s3a.fast.upload</name>
+    <value>false</value>
+    <description> NEW in hadoop 2.7 and UNSTABLE.
+    Upload directly from memory instead of buffering to
+    disk first. Memory usage and parallelism can be controlled as up to
+    fs.s3a.multipart.size memory is consumed for each (part)upload actively
+    uploading (fs.s3a.threads.max) or queueing (fs.s3a.max.total.tasks)</description>
+  </property>
+
+  <property>
+    <name>fs.s3a.attempts.maximum</name>
+    <value>50</value>
+    <description>How many times we should retry commands on transient errors.</description>
+  </property>
+
+  <property>
+    <name>fs.s3a.connection.maximum</name>
+    <value>100</value>
+    <description>Controls the maximum number of simultaneous connections to S3.</description>
+  </property>
+</configuration>


### PR DESCRIPTION
This PR makes the following changes:
* it removes the hack which updated /etc/hosts (it was needed with our previous VPC)
* file spark/conf/core-site.xml is copied to the cluster: it includes s3a configuration, and in particular property "fs.s3a.endpoint"

