### PR TITLE
fix: use level 'ERROR' for parquet logs for Spark 2.1

### DIFF
--- a/flintrock/scripts/install-spark.sh
+++ b/flintrock/scripts/install-spark.sh
@@ -35,3 +35,13 @@ mkdir "spark"
 # strip-components puts the files in the root of spark/
 tar xzf "$file" -C "spark" --strip-components=1
 rm "$file"
+
+# Because of https://issues.apache.org/jira/browse/SPARK-17993, Spark 2.1 displays very
+# verbose logs when reading parquet files, with the default log4j file.
+# This is fixed by SPARK-19219, which is released in Spark 2.2
+#
+# Workaround: if url contains "spark-2.1", use a copy of log4j.properties.template which
+# contains level "ERROR" for parquet logs (default file log4j-defaults.properties doesn't)
+if [[ $url == *"spark-2.1"* ]]; then
+  cp -p spark/conf/log4j.properties.template spark/conf/log4j.properties
+fi


### PR DESCRIPTION
This PR changes the log level to ERROR for parquet, to avoid very verbose logs in Spark 2.1, i.e.
```
WARN CorruptStatistics: Ignoring statistics because created_by could not be parsed (see PARQUET-251): parquet-mr version 1.6.0
org.apache.parquet.VersionParser$VersionParseException: Could not parse created_by: parquet-mr version 1.6.0 using format: (.+) version ((.*) )?\(build ?(.*)\)
  at org.apache.parquet.VersionParser.parse(VersionParser.java:112)
  ...
```

