### PR TITLE
Port features from 0.7 to 0.9

### DIFF
--- a/flintrock/config.yaml.template
+++ b/flintrock/config.yaml.template
@@ -26,7 +26,8 @@ providers:
     instance-type: m3.medium
     region: us-east-1
     # availability-zone: <name>
-    ami: ami-a4c7edb2   # Amazon Linux, us-east-1
+    # ami: ami-9398d3e0 # eu-west-1 - Amazon Linux AMI 2016.09 : HVM (SSD) Save on 64 bit EBS
+    ami: ami-3bfab942 # eu-west-1 Amazon Linux AMI 2017.09.1.20180307 x86_64 HVM GP2
     user: ec2-user
     # ami: ami-61bbf104   # CentOS 7, us-east-1
     # user: centos
@@ -45,6 +46,8 @@ providers:
     # min-root-ebs-size-gb: <size-gb>
     tenancy: default  # default | dedicated
     ebs-optimized: no  # yes | no
+    # use-private-network: # optional; defaults to False; if set to True, access-origins is required
+    # access-origins: # optional; must be written within quote; default to your public ip address
     instance-initiated-shutdown-behavior: terminate  # terminate | stop
     # user-data: /path/to/userdata/script
 

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -177,6 +177,17 @@ class FlintrockCluster:
             persistent=None)
         self.storage_dirs = storage_dirs
 
+
+    def subnet_is_private(self) -> bool:
+        """
+        A boolean set to true if the subnet is private..
+
+        Providers must override this property since it is typically derived from
+        an underlying object, like an EC2 instance.
+        """
+        raise NotImplementedError
+
+
     def destroy_check(self):
         """
         Check that the cluster is in a state in which it can be destroyed.
@@ -619,7 +630,7 @@ def provision_cluster(
 
     master_ssh_client = get_ssh_client(
         user=user,
-        host=cluster.master_host,
+        host=cluster.master_ip,
         identity_file=identity_file)
 
     with master_ssh_client:
@@ -644,7 +655,7 @@ def provision_cluster(
                 cluster=cluster)
 
     for service in services:
-        service.health_check(master_host=cluster.master_host)
+        service.health_check(master_host=cluster.master_ip)
 
 
 def provision_node(

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -475,6 +475,11 @@ def generate_template_mapping(
         'spark_root_ephemeral_dirs': spark_ephemeral_dirs if spark_ephemeral_dirs else spark_root_dir,
     }
 
+    try:
+        template_mapping['region'] = cluster.region
+    except AttributeError:
+        logger.error('Property region is not defined in variable cluster')
+
     return template_mapping
 
 

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -478,7 +478,16 @@ def generate_template_mapping(
     try:
         template_mapping['region'] = cluster.region
     except AttributeError:
-        logger.error('Property region is not defined in variable cluster')
+        logger.exception('Property region is not defined in variable cluster')
+
+    # TODO: remove the following lines when the migration to IAM roles is finished
+    try:
+        import botocore
+        credentials = botocore.session.get_session().get_credentials()
+        template_mapping['access_key'] = credentials.access_key
+        template_mapping['secret_key'] = credentials.secret_key
+    except:
+        logger.exception('Unable to set credentials')
 
     return template_mapping
 

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -64,6 +64,7 @@ class EC2Cluster(FlintrockCluster):
             vpc_id: str,
             master_instance: 'boto3.resources.factory.ec2.Instance',
             slave_instances: "List[boto3.resources.factory.ec2.Instance]",
+            use_private_network: bool,
             *args,
             **kwargs):
         super().__init__(*args, **kwargs)
@@ -71,6 +72,7 @@ class EC2Cluster(FlintrockCluster):
         self.vpc_id = vpc_id
         self.master_instance = master_instance
         self.slave_instances = slave_instances
+        self.use_private_network = use_private_network
 
     @property
     def instances(self):
@@ -81,19 +83,36 @@ class EC2Cluster(FlintrockCluster):
 
     @property
     def master_ip(self):
-        return self.master_instance.public_ip_address
+        if self.use_private_network:
+            return self.master_instance.private_ip_address
+        else:
+            return self.master_instance.public_ip_address
 
     @property
     def master_host(self):
-        return self.master_instance.public_dns_name
+        if self.use_private_network:
+            return self.master_instance.private_dns_name
+        else:
+            return self.master_instance.public_dns_name
 
     @property
     def slave_ips(self):
-        return [i.public_ip_address for i in self.slave_instances]
+        if self.use_private_network:
+            return [i.private_ip_address for i in self.slave_instances]
+        else:
+            return [i.public_ip_address for i in self.slave_instances]
 
     @property
     def slave_hosts(self):
-        return [i.public_dns_name for i in self.slave_instances]
+        if self.use_private_network:
+            return [i.private_dns_name for i in self.slave_instances]
+        else:
+            return [i.public_dns_name for i in self.slave_instances]
+
+    @property
+    def subnet_is_private(self):
+        ec2 = boto3.resource(service_name='ec2', region_name=self.region)
+        return not ec2.Subnet(self.master_instance.subnet_id).map_public_ip_on_launch
 
     @property
     def num_masters(self):
@@ -298,6 +317,7 @@ class EC2Cluster(FlintrockCluster):
                 user_data=user_data)
 
             slave_tags = [
+                {'Key': 'ENV', 'Value': 'DATA'},
                 {'Key': 'flintrock-role', 'Value': 'slave'},
                 {'Key': 'Name', 'Value': '{c}-slave'.format(c=self.name)}]
             slave_tags += tags
@@ -309,12 +329,12 @@ class EC2Cluster(FlintrockCluster):
                     ])
                 .create_tags(Tags=slave_tags))
 
-            existing_slaves = {i.public_ip_address for i in self.slave_instances}
+            existing_slaves = {i.private_ip_address if self.use_private_network else i.public_ip_address for i in self.slave_instances}
 
             self.slave_instances += new_slave_instances
             self.wait_for_state('running')
 
-            new_slaves = {i.public_ip_address for i in self.slave_instances} - existing_slaves
+            new_slaves = {i.private_ip_address if self.use_private_network else i.public_ip_address for i in self.slave_instances} - existing_slaves
 
             super().add_slaves(
                 user=user,
@@ -414,10 +434,10 @@ class EC2Cluster(FlintrockCluster):
         print('  state: {s}'.format(s=self.state))
         print('  node-count: {nc}'.format(nc=len(self.instances)))
         if self.state == 'running':
-            print('  master:', self.master_host if self.num_masters > 0 else '')
+            print('  master:', (self.master_ip if self.use_private_network else self.master_host) if self.num_masters > 0 else '')
             print(
                 '\n    - '.join(
-                    ['  slaves:'] + (self.slave_hosts if self.num_slaves > 0 else [])))
+                    ['  slaves:'] + ((self.slave_ips if self.use_private_network else self.slave_hosts) if self.num_slaves > 0 else [])))
         # print('...')
 
 
@@ -446,6 +466,7 @@ def check_network_config(*, region_name: str, vpc_id: str, subnet_id: str):
     """
     ec2 = boto3.resource(service_name='ec2', region_name=region_name)
 
+    """
     if not ec2.Vpc(vpc_id).describe_attribute(Attribute='enableDnsHostnames')['EnableDnsHostnames']['Value']:
         raise ConfigurationNotSupported(
             "{v} does not have DNS hostnames enabled. "
@@ -460,6 +481,7 @@ def check_network_config(*, region_name: str, vpc_id: str, subnet_id: str):
             "See: https://github.com/nchammas/flintrock/issues/14"
             .format(s=subnet_id)
         )
+    """
 
 
 def get_security_groups(
@@ -492,7 +514,8 @@ def get_or_create_flintrock_security_groups(
         *,
         cluster_name,
         vpc_id,
-        region) -> "List[boto3.resource('ec2').SecurityGroup]":
+        region,
+        access_origins) -> "List[boto3.resource('ec2').SecurityGroup]":
     """
     If they do not already exist, create all the security groups needed for a
     Flintrock cluster.
@@ -539,54 +562,63 @@ def get_or_create_flintrock_security_groups(
             VpcId=vpc_id)
 
     # Rules for the client interacting with the cluster.
-    flintrock_client_ip = (
-        urllib.request.urlopen('http://checkip.amazonaws.com/')
-        .read().decode('utf-8').strip())
-    flintrock_client_cidr = '{ip}/32'.format(ip=flintrock_client_ip)
+    flintrock_clients_cidr = []
+    if not access_origins:
+        flintrock_client_ip = (
+            urllib.request.urlopen('http://checkip.amazonaws.com/')
+            .read().decode('utf-8').strip())
+        flintrock_clients_cidr.append('{ip}/32'.format(ip=flintrock_client_ip))
+    else:
+        for item in access_origins.split(','):
+            flintrock_clients_cidr.append(item)
 
     # TODO: Services should be responsible for registering what ports they want exposed.
-    client_rules = [
-        # SSH
-        SecurityGroupRule(
-            ip_protocol='tcp',
-            from_port=22,
-            to_port=22,
-            cidr_ip=flintrock_client_cidr,
-            src_group=None),
-        # HDFS
-        SecurityGroupRule(
-            ip_protocol='tcp',
-            from_port=50070,
-            to_port=50070,
-            cidr_ip=flintrock_client_cidr,
-            src_group=None),
-        # Spark
-        SecurityGroupRule(
-            ip_protocol='tcp',
-            from_port=8080,
-            to_port=8081,
-            cidr_ip=flintrock_client_cidr,
-            src_group=None),
-        SecurityGroupRule(
-            ip_protocol='tcp',
-            from_port=4040,
-            to_port=4050,
-            cidr_ip=flintrock_client_cidr,
-            src_group=None),
-        SecurityGroupRule(
-            ip_protocol='tcp',
-            from_port=7077,
-            to_port=7077,
-            cidr_ip=flintrock_client_cidr,
-            src_group=None),
-        # Spark REST Server
-        SecurityGroupRule(
-            ip_protocol='tcp',
-            from_port=6066,
-            to_port=6066,
-            cidr_ip=flintrock_client_cidr,
-            src_group=None)
-    ]
+    client_rules = []
+    for flintrock_client_cidr in flintrock_clients_cidr:
+        rules = [
+            # SSH
+            SecurityGroupRule(
+                ip_protocol='tcp',
+                from_port=22,
+                to_port=22,
+                cidr_ip=flintrock_client_cidr,
+                src_group=None),
+            # HDFS
+            SecurityGroupRule(
+                ip_protocol='tcp',
+                from_port=50070,
+                to_port=50070,
+                cidr_ip=flintrock_client_cidr,
+                src_group=None),
+            # Spark
+            SecurityGroupRule(
+                ip_protocol='tcp',
+                from_port=8080,
+                to_port=8081,
+                cidr_ip=flintrock_client_cidr,
+                src_group=None),
+            SecurityGroupRule(
+                ip_protocol='tcp',
+                from_port=4040,
+                to_port=4050,
+                cidr_ip=flintrock_client_cidr,
+                src_group=None),
+            SecurityGroupRule(
+                ip_protocol='tcp',
+                from_port=7077,
+                to_port=7077,
+                cidr_ip=flintrock_client_cidr,
+                src_group=None),
+            # Spark REST Server
+            SecurityGroupRule(
+                ip_protocol='tcp',
+                from_port=6066,
+                to_port=6066,
+                cidr_ip=flintrock_client_cidr,
+                src_group=None)
+        ]
+
+        client_rules.extend(rules)
 
     # TODO: Don't try adding rules that already exist.
     # TODO: Add rules in one shot.
@@ -831,7 +863,9 @@ def launch(
         ebs_optimized=False,
         instance_initiated_shutdown_behavior='stop',
         user_data,
-        tags):
+        tags,
+        use_private_network=False,
+        access_origins=''):
     """
     Launch a cluster.
     """
@@ -849,7 +883,8 @@ def launch(
         get_cluster(
             cluster_name=cluster_name,
             region=region,
-            vpc_id=vpc_id)
+            vpc_id=vpc_id,
+            use_private_network=use_private_network)
     except ClusterNotFound as e:
         pass
     else:
@@ -862,7 +897,8 @@ def launch(
     flintrock_security_groups = get_or_create_flintrock_security_groups(
         cluster_name=cluster_name,
         vpc_id=vpc_id,
-        region=region)
+        region=region,
+        access_origins=access_origins)
     user_security_groups = get_security_groups(
         vpc_id=vpc_id,
         region=region,
@@ -914,6 +950,7 @@ def launch(
         slave_instances = cluster_instances[1:]
 
         master_tags = [
+            {'Key': 'ENV', 'Value': 'DATA'},
             {'Key': 'flintrock-role', 'Value': 'master'},
             {'Key': 'Name', 'Value': '{c}-master'.format(c=cluster_name)}]
         master_tags += tags
@@ -926,6 +963,7 @@ def launch(
             .create_tags(Tags=master_tags))
 
         slave_tags = [
+            {'Key': 'ENV', 'Value': 'DATA'},
             {'Key': 'flintrock-role', 'Value': 'slave'},
             {'Key': 'Name', 'Value': '{c}-slave'.format(c=cluster_name)}]
         slave_tags += tags
@@ -943,7 +981,8 @@ def launch(
             vpc_id=vpc_id,
             ssh_key_pair=generate_ssh_key_pair(),
             master_instance=master_instance,
-            slave_instances=slave_instances)
+            slave_instances=slave_instances,
+            use_private_network=use_private_network)
 
         cluster.wait_for_state('running')
 
@@ -970,18 +1009,21 @@ def launch(
         raise
 
 
-def get_cluster(*, cluster_name: str, region: str, vpc_id: str) -> EC2Cluster:
+def get_cluster(*, cluster_name: str, region: str, vpc_id: str, use_private_network: bool) -> EC2Cluster:
+
     """
     Get an existing EC2 cluster.
     """
     cluster = get_clusters(
         cluster_names=[cluster_name],
         region=region,
-        vpc_id=vpc_id)
+        vpc_id=vpc_id,
+        use_private_network=use_private_network)
+
     return cluster[0]
 
 
-def get_clusters(*, cluster_names: list=[], region: str, vpc_id: str) -> list:
+def get_clusters(*, cluster_names: list=[], region: str, vpc_id: str, use_private_network: bool) -> list:
     """
     Get all the named clusters. If no names are given, get all clusters.
 
@@ -1021,7 +1063,8 @@ def get_clusters(*, cluster_names: list=[], region: str, vpc_id: str) -> list:
             region=region,
             vpc_id=vpc_id,
             instances=list(filter(
-                lambda x: _get_cluster_name(x) == cluster_name, all_clusters_instances)))
+                lambda x: _get_cluster_name(x) == cluster_name, all_clusters_instances)),
+            use_private_network=use_private_network)
         for cluster_name in found_cluster_names]
 
     return clusters
@@ -1096,7 +1139,7 @@ def _get_cluster_master_slaves(
     return (master_instance, slave_instances)
 
 
-def _compose_cluster(*, name: str, region: str, vpc_id: str, instances: list) -> EC2Cluster:
+def _compose_cluster(*, name: str, region: str, vpc_id: str, instances: list, use_private_network: bool) -> EC2Cluster:
     """
     Compose an EC2Cluster object from a set of raw EC2 instances representing
     a Flintrock cluster.
@@ -1108,7 +1151,8 @@ def _compose_cluster(*, name: str, region: str, vpc_id: str, instances: list) ->
         region=region,
         vpc_id=vpc_id,
         master_instance=master_instance,
-        slave_instances=slave_instances)
+        slave_instances=slave_instances,
+        use_private_network=use_private_network)
 
     return cluster
 

--- a/flintrock/ec2.py
+++ b/flintrock/ec2.py
@@ -1043,6 +1043,7 @@ def get_clusters(*, cluster_names: list=[], region: str, vpc_id: str, use_privat
     all_clusters_instances = list(
         ec2.instances.filter(
             Filters=[
+                {'Name': 'instance-state-name', 'Values': ['pending', 'running', 'stopping', 'stopped']},
                 {'Name': 'instance.group-name', 'Values': group_name_filter},
                 {'Name': 'vpc-id', 'Values': [vpc_id]},
             ]))

--- a/flintrock/scripts/install-spark.sh
+++ b/flintrock/scripts/install-spark.sh
@@ -35,3 +35,13 @@ mkdir "spark"
 # strip-components puts the files in the root of spark/
 tar xzf "$file" -C "spark" --strip-components=1
 rm "$file"
+
+# Because of https://issues.apache.org/jira/browse/SPARK-17993, Spark 2.1 displays very
+# verbose logs when reading parquet files, with the default log4j file.
+# This is fixed by SPARK-19219, which is released in Spark 2.2
+#
+# Workaround: if url contains "spark-2.1", use a copy of log4j.properties.template which
+# contains level "ERROR" for parquet logs (default file log4j-defaults.properties doesn't)
+if [[ $url == *"spark-2.1"* ]]; then
+  cp -p spark/conf/log4j.properties.template spark/conf/log4j.properties
+fi

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -343,6 +343,7 @@ class Spark(FlintrockService):
             cluster: FlintrockCluster):
 
         template_paths = [
+            'spark/conf/core-site.xml',
             'spark/conf/spark-env.sh',
             'spark/conf/slaves',
             'spark/conf/spark-defaults.conf',

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -148,6 +148,10 @@ class HDFS(FlintrockService):
             self,
             ssh_client: paramiko.client.SSHClient,
             cluster: FlintrockCluster):
+
+        logger.info("[{h}] Configuring HDFS...".format(
+            h=ssh_client.get_transport().getpeername()[0]))
+
         # TODO: os.walk() through these files.
         template_paths = [
             'hadoop/conf/masters',

--- a/flintrock/templates/hadoop/conf/core-site.xml
+++ b/flintrock/templates/hadoop/conf/core-site.xml
@@ -9,6 +9,6 @@
 
   <property>
     <name>fs.defaultFS</name>
-    <value>hdfs://{master_host}:9000</value>
+    <value>hdfs://{master_ip}:9000</value>
   </property>
 </configuration>

--- a/flintrock/templates/hadoop/conf/hdfs-site.xml
+++ b/flintrock/templates/hadoop/conf/hdfs-site.xml
@@ -11,4 +11,27 @@
     <name>dfs.datanode.data.dir</name>
     <value>{hadoop_root_ephemeral_dirs}</value>
   </property>
+
+  <!-- With the following value, a datanote will be dead after ~2 minutes.
+  This is useful when using flintrock remove-slaves
+
+	See https://community.hortonworks.com/questions/2474/how-to-identify-stale-datanode.html for more info
+	-->
+  <property>
+    <name>dfs.namenode.heartbeat.recheck-interval</name>
+    <value>60000</value><!-- 1 minute. Default value is 5 minutes -->
+  </property>
+
+  <!-- give lowest priority for reads when a datanode is stale -->
+  <property>
+    <name>dfs.namenode.avoid.read.stale.datanode</name>
+    <value>true</value>
+  </property>
+
+  <!-- give lowest priority for writes when a datanode is stale -->
+  <property>
+    <name>dfs.namenode.avoid.write.stale.datanode</name>
+    <value>true</value>
+  </property>
+
 </configuration>

--- a/flintrock/templates/spark/conf/core-site.xml
+++ b/flintrock/templates/spark/conf/core-site.xml
@@ -28,7 +28,6 @@
     <value>org.apache.hadoop.fs.s3a.S3AFileSystem</value>
   </property>
 
-  <!-- The following properties are no longer needed because we use roles
   <property>
     <name>fs.s3a.access.key</name>
     <value>{access_key}</value>
@@ -38,7 +37,6 @@
     <name>fs.s3a.secret.key</name>
     <value>{secret_key}</value>
   </property>
-  -->
 
   <property>
     <name>fs.s3a.buffer.dir</name>

--- a/flintrock/templates/spark/conf/core-site.xml
+++ b/flintrock/templates/spark/conf/core-site.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+  <property>
+    <name>hadoop.tmp.dir</name>
+    <value>{hadoop_ephemeral_dirs}</value>
+  </property>
+
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://{master_ip}:9000</value>
+    <description> By default, write to HDFS if no scheme is specified</description>
+  </property>
+
+  <property>
+    <name>fs.s3a.endpoint</name>
+    <value>s3-{region}.amazonaws.com</value>
+    <final>true</final>
+    <description>AWS S3 endpoint to connect to. An up-to-date list is
+      provided in the AWS Documentation: regions and endpoints. Without this
+      property, the standard region (s3.amazonaws.com) is assumed.
+    </description>
+  </property>
+
+  <property>
+    <name>fs.s3a.impl</name>
+    <value>org.apache.hadoop.fs.s3a.S3AFileSystem</value>
+  </property>
+
+  <!-- The following properties are no longer needed because we use roles
+  <property>
+    <name>fs.s3a.access.key</name>
+    <value>{access_key}</value>
+  </property>
+
+  <property>
+    <name>fs.s3a.secret.key</name>
+    <value>{secret_key}</value>
+  </property>
+  -->
+
+  <property>
+    <name>fs.s3a.buffer.dir</name>
+    <value>/home/ec2-user/spark/work,/tmp</value>
+  </property>
+
+  <property>
+    <name>fs.s3a.fast.upload</name>
+    <value>false</value>
+    <description> NEW in hadoop 2.7 and UNSTABLE.
+      Upload directly from memory instead of buffering to
+      disk first. Memory usage and parallelism can be controlled as up to
+      fs.s3a.multipart.size memory is consumed for each (part)upload actively
+      uploading (fs.s3a.threads.max) or queueing (fs.s3a.max.total.tasks)
+    </description>
+  </property>
+
+  <property>
+    <name>fs.s3a.attempts.maximum</name>
+    <value>50</value>
+    <description>How many times we should retry commands on transient errors.</description>
+  </property>
+
+  <property>
+    <name>fs.s3a.connection.maximum</name>
+    <value>1000</value>
+    <description>Controls the maximum number of simultaneous connections to S3.
+      NB: fs.s3a.connection.maximum must be larger than fs.s3a.threads.max,
+      to avoid org.apache.http.conn.ConnectionPoolTimeoutException
+    </description>
+  </property>
+</configuration>

--- a/flintrock/templates/spark/conf/spark-env.sh
+++ b/flintrock/templates/spark/conf/spark-env.sh
@@ -7,14 +7,19 @@ export SPARK_EXECUTOR_INSTANCES="{spark_executor_instances}"
 export SPARK_EXECUTOR_CORES="$(($(nproc) / {spark_executor_instances}))"
 export SPARK_WORKER_CORES="$(nproc)"
 
-export SPARK_MASTER_HOST="{master_host}"
+export SPARK_MASTER_HOST="{master_ip}"
+
+# Needed for spark 1.6.x
+export SPARK_MASTER_IP="{master_ip}"
 
 # TODO: Make this dependent on HDFS install.
 export HADOOP_CONF_DIR="$HOME/hadoop/conf"
 
 # TODO: Make this non-EC2-specific.
-# Bind Spark's web UIs to this machine's public EC2 hostname
-export SPARK_PUBLIC_DNS="$(curl --silent http://169.254.169.254/latest/meta-data/public-hostname)"
+# SPARK_PUBLIC_DNS="$(curl --silent http://169.254.169.254/latest/meta-data/public-hostname)"
+# Bind Spark's web UIs to this machine's private IP
+SPARK_PUBLIC_DNS="$(curl --silent http://169.254.169.254/latest/meta-data/local-ipv4)"
+export SPARK_PUBLIC_DNS
 
 # TODO: Set a high ulimit for large shuffles
 # Need to find a way to do this, since "sudo ulimit..." doesn't fly.


### PR DESCRIPTION
This PR ports features and configuration properties that are specific to our fork of Flintrock 0.7 to our fork of Flintrock 0.9:
- use a private network
- in HDFS configuration, decrease heartbeat check-interval so that a datanode will be dead after ~2 minutes. This is useful when removing slaves
- copy spark configuration (endpoint, s3a...) to cluster
- use level 'ERROR' for parquet logs for Spark 2.1.x
- fix flintrock describe, by only listing pending and running instances