### PR TITLE
[DMP-402]fix: remove packages from spark-defaults.conf

### DIFF
--- a/flintrock/templates/spark/conf/spark-defaults.conf
+++ b/flintrock/templates/spark/conf/spark-defaults.conf
@@ -1,1 +1,1 @@
-spark.jars.packages    org.apache.hadoop:hadoop-aws:{hadoop_version}
+# spark.jars.packages    org.apache.hadoop:hadoop-aws:{hadoop_version}


### PR DESCRIPTION
Some driver logs only contain the following message:
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/ec2-user/spark/jars/slf4j-log4j12-1.7.16.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/ec2-user/hadoop/share/hadoop/common/lib/slf4j-log4j12-1.7.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
```

This error happens when:
- some slaves have been added using "flintrock add-slaves"
- the driver is one of the added slaves
- we use --deploy-mode cluster

Removing spark.jar.packages from spark-defaults.conf removes this bug