### PR TITLE
[DMP-464]feature: allow user to use Spark's Hadoop Free Build. Feature: periodically delete folders of finished applications in "spark/work"

### DIFF
--- a/flintrock/__init__.py
+++ b/flintrock/__init__.py
@@ -1,2 +1,2 @@
 # See: https://packaging.python.org/en/latest/distributing/#standards-compliance-for-interoperability
-__version__ = '0.9.3'
+__version__ = '0.9.4.dev'

--- a/flintrock/services.py
+++ b/flintrock/services.py
@@ -348,7 +348,26 @@ class Spark(FlintrockService):
             'spark/conf/slaves',
             'spark/conf/spark-defaults.conf',
         ]
+
+        # Export SPARK_DIST_CLASSPATH if user wants to use Spark's "Hadoop Free" Build.
+        # Cf https://spark.apache.org/docs/2.2.0/hadoop-provided.html
+        # This allows us to use Hadoop 2.8.
+        # NB: slf4jars are excluded, to avoid error "SLF4J: Class path contains multiple SLF4J bindings" (when
+        # multiple bindings are found, Spark logs are not written)
+        spark_dist_classpath = (
+            'export SPARK_DIST_CLASSPATH=$(hadoop classpath | '
+            'sed "s;/home/ec2-user/hadoop/share/hadoop/common/lib/slf4j[-\.a-z0-9]*\.jar:;;g")'
+        ) if 'without-hadoop' in self.download_source else ''
+
         for template_path in template_paths:
+            mapping = generate_template_mapping(
+                cluster=cluster,
+                spark_executor_instances=self.spark_executor_instances,
+                hadoop_version=self.hadoop_version,
+                spark_version=self.version or self.git_commit,
+            )
+            mapping['spark_dist_classpath'] = spark_dist_classpath
+
             ssh_check_output(
                 client=ssh_client,
                 command="""
@@ -357,12 +376,7 @@ class Spark(FlintrockService):
                     f=shlex.quote(
                         get_formatted_template(
                             path=os.path.join(THIS_DIR, "templates", template_path),
-                            mapping=generate_template_mapping(
-                                cluster=cluster,
-                                spark_executor_instances=self.spark_executor_instances,
-                                hadoop_version=self.hadoop_version,
-                                spark_version=self.version or self.git_commit,
-                            ))),
+                            mapping=mapping)),
                     p=shlex.quote(template_path)))
 
     # TODO: Convert this into start_master() and split master- or slave-specific

--- a/flintrock/templates/spark/conf/spark-env.sh
+++ b/flintrock/templates/spark/conf/spark-env.sh
@@ -25,3 +25,5 @@ export SPARK_PUBLIC_DNS
 # Need to find a way to do this, since "sudo ulimit..." doesn't fly.
 # Probably need to edit some Linux config file.
 # ulimit -n 1000000
+
+{spark_dist_classpath}

--- a/flintrock/templates/spark/conf/spark-env.sh
+++ b/flintrock/templates/spark/conf/spark-env.sh
@@ -12,6 +12,11 @@ export SPARK_MASTER_HOST="{master_ip}"
 # Needed for spark 1.6.x
 export SPARK_MASTER_IP="{master_ip}"
 
+# Every hour, delete folders of finished applications in "spark/work" that are older than 4 hours.
+# This is important for Spark applications that are executed regularly, e.g. every 30 minutes,
+# because each folder in "spark/work" contains the application jar (around 40 MB)
+export SPARK_WORKER_OPTS="-Dspark.worker.cleanup.enabled=true -Dspark.worker.cleanup.interval=3600 -Dspark.worker.cleanup.appDataTtl=14400"
+
 # TODO: Make this dependent on HDFS install.
 export HADOOP_CONF_DIR="$HOME/hadoop/conf"
 


### PR DESCRIPTION
This PR makes the following changes:
* change spark-env.sh, so that every hour, folders of finished applications in "spark/work" are deleted
* allow users to use Spark's Hadoop Free Build (i.e. to use 'https://s3.amazonaws.com/spark-related-packages/spark-{v}-bin-without-hadoop.tgz' instead of 'https://nexus.adotmob.com/content/groups/public/org/apache/spark/{v}-hadoop2.7/spark-{v}-hadoop2.7.tgz' for the download-source), so that they can use Hadoop 2.8 (or a more recent version) with Spark.

As explained in https://spark.apache.org/docs/2.2.0/hadoop-provided.html, SPARK_DIST_CLASSPATH will be modified.

