### PR TITLE
[DATA-891]feature: use instance profile credentials

### DIFF
--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -480,7 +480,20 @@ def generate_template_mapping(
     except AttributeError:
         logger.exception('Property region is not defined in variable cluster')
 
-    # TODO: remove the following lines when the migration to IAM roles is finished
+    # NB: "instance profile credentials" are used by default: they are obtained thanks to parameter
+    # "instance-profile-name" in the Flintrock configuration file.
+    #
+    # If needed, a user can use his/her AWS credentials by adding the following lines to
+    # "templates/spark/conf/core-site.xml":
+    #    <property>
+    #      <name>fs.s3a.access.key</name>
+    #      <value>{access_key}</value>
+    #    </property>
+    #
+    #    <property>
+    #      <name>fs.s3a.secret.key</name>
+    #      <value>{secret_key}</value>
+    #    </property>
     try:
         import botocore
         credentials = botocore.session.get_session().get_credentials()

--- a/flintrock/templates/spark/conf/core-site.xml
+++ b/flintrock/templates/spark/conf/core-site.xml
@@ -29,16 +29,6 @@
   </property>
 
   <property>
-    <name>fs.s3a.access.key</name>
-    <value>{access_key}</value>
-  </property>
-
-  <property>
-    <name>fs.s3a.secret.key</name>
-    <value>{secret_key}</value>
-  </property>
-
-  <property>
     <name>fs.s3a.buffer.dir</name>
     <value>/home/ec2-user/spark/work,/tmp</value>
   </property>


### PR DESCRIPTION
This PR makes the following change:
* remove properties "fs.s3a.access.key" and "fs.s3a.secret.key" from flintrock/templates/spark/conf/core-site.xml so that instance profile credentials (i.e. the IAM role defined by "instance-profile-name" in the Flintrock configuration file) are used. As explained by https://hadoop.apache.org/docs/r2.7.3/hadoop-aws/tools/hadoop-aws/index.html, those two properties must be omitted to use instance profile credentials

Fixes issue DATA-891
