### PR TITLE
feature: add default core site properties to use google service account

### DIFF
--- a/flintrock/templates/spark/conf/core-site.xml
+++ b/flintrock/templates/spark/conf/core-site.xml
@@ -58,4 +58,18 @@
       to avoid org.apache.http.conn.ConnectionPoolTimeoutException
     </description>
   </property>
+
+  <property>
+    <name>google.cloud.auth.service.account.enable</name>
+    <value>true</value>
+  </property>
+
+  <property>
+    <name>google.cloud.auth.service.account.json.keyfile</name>
+    <value>/home/ec2-user/google-service-account.json</value>
+    <description>
+      The JSON key file of the service account used for GCS
+      access when google.cloud.auth.service.account.enable is true.
+    </description>
+  </property>
 </configuration>


### PR DESCRIPTION
This PR makes the following changes:
* Add default spark properties in core site xml in order to use google cloud service account keys
