### PR TITLE
[DMP-1373]feature: enable REST API for Spark 2.4+

### DIFF
--- a/flintrock/__init__.py
+++ b/flintrock/__init__.py
@@ -1,2 +1,2 @@
 # See: https://packaging.python.org/en/latest/distributing/#standards-compliance-for-interoperability
-__version__ = '0.9.6'
+__version__ = '0.9.7.dev'

--- a/flintrock/core.py
+++ b/flintrock/core.py
@@ -502,6 +502,14 @@ def generate_template_mapping(
     except:
         logger.exception('Unable to set credentials')
 
+    if spark_version:  # "spark_version" can be empty, e.g. in services.HDFS
+        # Since Spark 2.4.0, the REST API is disabled by default. Cf https://issues.apache.org/jira/browse/SPARK-25088
+        # The following lines enable it for Spark 2.4+
+        spark_major_version, spark_minor_version = [int(x) for x in spark_version.split('.')[:2]]
+
+        template_mapping['enable_spark_rest_api'] = 'spark.master.rest.enabled true' \
+            if spark_major_version > 2 or (spark_major_version == 2 and spark_minor_version >= 4) else ''
+
     return template_mapping
 
 

--- a/flintrock/templates/spark/conf/spark-defaults.conf
+++ b/flintrock/templates/spark/conf/spark-defaults.conf
@@ -1,1 +1,2 @@
 spark.jars.packages    org.apache.hadoop:hadoop-aws:{hadoop_version}
+{enable_spark_rest_api}

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setuptools.setup(
         # of Flintrock intermittently fail due to an out-of-date version
         # of Cryptography being used.
         # See: https://github.com/nchammas/flintrock/issues/169
-        'cryptography == 1.7.2',
+        'cryptography == 2.6.1',
     ],
 
     entry_points={


### PR DESCRIPTION
This PR makes the following changes:
* enable Spark REST API for Spark 2.4+ (because it is disabled by default since Spark 2.4.0)
* update cryptography from 1.7.2 to 2.6.1, so that `pip install -r requirements/maintainer.pip` works with container `python:3.5.7`
